### PR TITLE
Add privacy policy page

### DIFF
--- a/content/footer/footer.md
+++ b/content/footer/footer.md
@@ -10,6 +10,8 @@ sections:
         url: /contact
       - label: Terms and Conditions
         url: /
+      - label: Privacy Policy
+        url: /privacy-policy
   - title: Services
     type: links
     description: ''

--- a/src/app/(landing)/privacy-policy/page.tsx
+++ b/src/app/(landing)/privacy-policy/page.tsx
@@ -1,16 +1,9 @@
-import HeroSection from "@/components/landing/HeroSection";
-
-const heroBlock = {
-  message: `# Our Commitment to Your Privacy\n\nWe value the trust you place in SoftCanada.`,
-  buttonText: "",
-  buttonLink: "",
-  backgroundImage: "/images/landing/hero_section_bg.jpg",
-};
+import PrivacyHero from "@/components/landing/privacy/PrivacyHero";
 
 export default function PrivacyPolicyPage() {
   return (
     <div className="-mt-16">
-      <HeroSection {...heroBlock} />
+      <PrivacyHero />
       <div className="max-w-3xl mx-auto px-5 py-12 space-y-8 text-gray-700">
         <h2 className="text-2xl font-semibold">1. Information We Collect</h2>
         <p>

--- a/src/app/(landing)/privacy-policy/page.tsx
+++ b/src/app/(landing)/privacy-policy/page.tsx
@@ -1,0 +1,46 @@
+import HeroSection from "@/components/landing/HeroSection";
+
+const heroBlock = {
+  message: `# Our Commitment to Your Privacy\n\nWe value the trust you place in SoftCanada.`,
+  buttonText: "",
+  buttonLink: "",
+  backgroundImage: "/images/landing/hero_section_bg.jpg",
+};
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="-mt-16">
+      <HeroSection {...heroBlock} />
+      <div className="max-w-3xl mx-auto px-5 py-12 space-y-8 text-gray-700">
+        <h2 className="text-2xl font-semibold">1. Information We Collect</h2>
+        <p>
+          We collect information you provide when creating an account, filling out forms or using features such as job tools, real estate resources and immigration guides. This may include your name, contact details and any other data you choose to share.
+        </p>
+        <h2 className="text-2xl font-semibold">2. How We Use Your Information</h2>
+        <p>
+          Your information enables us to operate SoftCanada, personalize your experience and respond to your requests. We may also use aggregated data to improve our services and for analytics.
+        </p>
+        <h2 className="text-2xl font-semibold">3. Sharing Information</h2>
+        <p>
+          We do not sell your personal data. We may share it with service providers that assist with authentication, analytics or other business operations. These partners are required to protect your information.
+        </p>
+        <h2 className="text-2xl font-semibold">4. Cookies</h2>
+        <p>
+          SoftCanada uses cookies and similar technologies to remember your preferences and analyze site traffic.
+        </p>
+        <h2 className="text-2xl font-semibold">5. Data Security</h2>
+        <p>
+          We maintain reasonable safeguards to protect your information, but no online service is completely secure.
+        </p>
+        <h2 className="text-2xl font-semibold">6. Your Choices</h2>
+        <p>
+          You may update or delete your account at any time. For questions about your data, contact us at <a href="mailto:hello@softcanada.com" className="text-red-600">hello@softcanada.com</a>.
+        </p>
+        <h2 className="text-2xl font-semibold">7. Changes to This Policy</h2>
+        <p>
+          We may update this policy from time to time. Significant changes will be posted on this page.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/landing/Navbar.tsx
+++ b/src/components/landing/Navbar.tsx
@@ -222,8 +222,6 @@ export default function Navbar() {
 
     if (activeKey !== undefined) {
       setSelectedKeys(activeKey ? [activeKey.toString()] : []);
-    } else {
-      setSelectedKeys([]);
     }
   }, [pathname]);
 

--- a/src/components/landing/Navbar.tsx
+++ b/src/components/landing/Navbar.tsx
@@ -222,6 +222,8 @@ export default function Navbar() {
 
     if (activeKey !== undefined) {
       setSelectedKeys(activeKey ? [activeKey.toString()] : []);
+    } else {
+      setSelectedKeys([]);
     }
   }, [pathname]);
 

--- a/src/components/landing/Navbar.tsx
+++ b/src/components/landing/Navbar.tsx
@@ -219,9 +219,12 @@ export default function Navbar() {
     const activeKey = menuItems.find(
       (item) => item?.key?.toString() === basePath
     )?.key;
-    if (activeKey !== undefined)
+
+    if (activeKey !== undefined) {
       setSelectedKeys(activeKey ? [activeKey.toString()] : []);
-    if (pathname === "/") setSelectedKeys([]);
+    } else {
+      setSelectedKeys([]);
+    }
   }, [pathname]);
 
   return (

--- a/src/components/landing/privacy/PrivacyHero.tsx
+++ b/src/components/landing/privacy/PrivacyHero.tsx
@@ -11,7 +11,9 @@ const PrivacyHero: React.FC = () => {
     >
       <div
         className="absolute inset-0 bg-cover bg-center"
-        style={{ backgroundImage: `url('/images/landing/hero_section_bg.jpg')` }}
+        style={{
+          backgroundImage: `url('/images/landing/privacy_hero_section_bg.jpg')`,
+        }}
       />
       <div className="absolute inset-0 bg-black bg-opacity-50" />
       <div className="relative flex flex-col justify-end items-start pb-10 h-full px-8 sm:px-16 text-white z-10">

--- a/src/components/landing/privacy/PrivacyHero.tsx
+++ b/src/components/landing/privacy/PrivacyHero.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import React from "react";
+
+const PrivacyHero: React.FC = () => {
+  return (
+    <section
+      className="relative w-full mx-auto overflow-hidden shadow-lg bg-white"
+      style={{ height: "80vh" }}
+      id="hero-section"
+    >
+      <div
+        className="absolute inset-0 bg-cover bg-center"
+        style={{ backgroundImage: `url('/images/landing/hero_section_bg.jpg')` }}
+      />
+      <div className="absolute inset-0 bg-black bg-opacity-50" />
+      <div className="relative flex flex-col justify-end items-start pb-10 h-full px-8 sm:px-16 text-white z-10">
+        <div className="w-full max-w-[1000px] space-y-6">
+          <h1 className="text-3xl sm:text-5xl font-bold leading-snug break-words">
+            Privacy Policy
+          </h1>
+          <p className="text-lg mt-4 break-words sm:max-w-[700px]">
+            Learn how SoftCanada collects, uses and protects your data.
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default PrivacyHero;


### PR DESCRIPTION
## Summary
- create a new privacy policy page under landing routes
- add link to the policy in the footer

## Testing
- `npm run lint` *(fails: multiple existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6848b41751648321987328c178118729